### PR TITLE
Fixed crash by changing diagram to @diagram

### DIFF
--- a/lib/umlify/runner.rb
+++ b/lib/umlify/runner.rb
@@ -25,20 +25,20 @@ module Umlify
         parser_sexp = ParserSexp.new @args
 
         if classes = parser_sexp.parse_sources!
-          diagram = Diagram.new
+          @diagram = Diagram.new
 
           if @smart_mode
             classes.each {|c| c.infer_types! classes}
           end
 
-          diagram.create do
+          @diagram.create do
             classes.each {|c| add c}
           end.compute!
 
-          image = download_image(diagram.get_uri)
+          image = download_image(@diagram.get_uri)
           save_to_file image
 
-          puts 'http://yuml.me'+diagram.get_uri if @html_mode
+          puts 'http://yuml.me'+@diagram.get_uri if @html_mode
           puts "Saved in uml.png."
         else
           puts "No ruby files in the directory."


### PR DESCRIPTION
Hello, I was getting the following error:

....../umlify-1.2.9/lib/umlify/runner.rb:68:in `download_image': undefined method`get_dsl' for  
nil:NilClass (NoMethodError) 

I looked through the code briefly, changed the 'diagram' variable that the get_dsl was complaining about to @diagram.  I rebuilt the gem and it worked, all the tests still pass.

(Full Trace)

~/cs/ruby/umlify $ umlify lib/_/_  
umlify lib/_/_  
processing lib/umlify/diagram.rb...  
processing lib/umlify/extension.rb...  
processing lib/umlify/parser_sexp.rb...  
processing lib/umlify/runner.rb...  
processing lib/umlify/uml_class.rb...  
processing lib/umlify/version.rb...  
/Users/jorge/.rvm/gems/ruby-1.9.3-p125/gems/umlify-1.2.9/lib/umlify/runner.rb:68:in `download_image': undefined method`get_dsl' for  
nil:NilClass (NoMethodError)  
    from /Users/jorge/.rvm/gems/ruby-1.9.3-p125/gems/umlify-1.2.9/lib/umlify/runner.rb:38:in `run'                                     
    from /Users/jorge/.rvm/gems/ruby-1.9.3-p125/gems/umlify-1.2.9/bin/umlify:6:in`<top (required)>'  
    from /Users/jorge/.rvm/gems/ruby-1.9.3-p125/bin/umlify:19:in `load'                                                                
    from /Users/jorge/.rvm/gems/ruby-1.9.3-p125/bin/umlify:19:in`<main>' 
